### PR TITLE
Adds /getProgram endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,8 +58,8 @@ app.post("/deleteProgram", upload.array(), async function(req, res) {
   });
 });
 
-app.post("/getProgram", upload.array(), async function(req, res) {
-  let result = await lib.getProgram(req.body || {});
+app.get("/getProgram/:docid", upload.array(), async function(req, res) {
+  let result = await lib.getProgram(req.params.docid);
 
   return res.status(200).send({
     ...result,

--- a/app.js
+++ b/app.js
@@ -58,6 +58,14 @@ app.post("/deleteProgram", upload.array(), async function(req, res) {
   });
 });
 
+app.post("/getProgram", upload.array(), async function(req, res) {
+  let result = await lib.getProgram(req.body || {});
+
+  return res.status(200).send({
+    ...result,
+  });
+});
+
 // Start the server
 const PORT = process.env.PORT || 8081;
 app.listen(PORT, () => {

--- a/lib/getProgram.js
+++ b/lib/getProgram.js
@@ -1,0 +1,51 @@
+const firestore = require("../firebase");
+const winston = require("winston");
+
+/**---------getProgram--------------
+ * retrieves a program document
+ */
+
+/**--------Parameters (inside of body)------------
+ * docID: key for document
+ */
+const getProgram = async function(body) {
+  const { docID } = body;
+
+  winston.info(`Starting async get sketch`);
+  winston.info(`docID: ${docID}`);
+
+  if (!body) {
+    winston.error("No JSON provided, Exiting");
+    return { ok: false, error: "No json provided" };
+  }
+
+  if (!docID) {
+    winston.error("No Document ID provided, exiting...");
+    return {
+      ok: false,
+      error: "No docID provided",
+    };
+  }
+
+  try {
+    winston.info(`Getting sketch document...`);
+
+    let doc = await firestore
+      .collection("/programs")
+      .doc(docID)
+      .get();
+    winston.info(`Got doc. Returning...`);
+    return {
+      ok: true,
+      sketch: doc.data(),
+    };
+  } catch (err) {
+    winston.error(`Failed to get program for ${docID}. Received error: ${err}`);
+    return {
+      ok: false,
+      error: `Failed to get program, error: ${err}`,
+    };
+  }
+};
+
+module.exports = getProgram;

--- a/lib/getProgram.js
+++ b/lib/getProgram.js
@@ -8,16 +8,9 @@ const winston = require("winston");
 /**--------Parameters (inside of body)------------
  * docID: key for document
  */
-const getProgram = async function(body) {
-  const { docID } = body;
-
+const getProgram = async function(docID) {
   winston.info(`Starting async get sketch`);
   winston.info(`docID: ${docID}`);
-
-  if (!body) {
-    winston.error("No JSON provided, Exiting");
-    return { ok: false, error: "No json provided" };
-  }
 
   if (!docID) {
     winston.error("No Document ID provided, exiting...");

--- a/lib/getProgram.js
+++ b/lib/getProgram.js
@@ -1,5 +1,6 @@
 const firestore = require("../firebase");
 const winston = require("winston");
+const helpers = require("./helpers");
 
 /**---------getProgram--------------
  * retrieves a program document
@@ -27,7 +28,16 @@ const getProgram = async function(docID) {
       .collection("/programs")
       .doc(docID)
       .get();
-    winston.info(`Got doc. Returning...`);
+    winston.info(`Got doc. Checking if empty...`);
+    if (helpers.isObjectEmpty(doc.data())) {
+      winston.info(`Empty => doc does not exist. Returning...`);
+      winston.error(`Sketch with key ${docID} not found`);
+      return {
+        ok: false,
+        error: `Sketch with key ${docID} not found`,
+      };
+    }
+    winston.info(`Doc exists, returning...`);
     return {
       ok: true,
       sketch: doc.data(),

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,10 @@
+const isObjectEmpty = function(obj) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) return false;
+  }
+  return true;
+};
+
+module.exports = {
+  isObjectEmpty,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const updateUserData = require("./updateUserData");
 const updatePrograms = require("./updatePrograms");
 const createProgram = require("./createProgram");
 const deleteProgram = require("./deleteProgram");
+const getProgram = require("./getProgram");
 
 module.exports = {
   initializeUserData,
@@ -12,4 +13,5 @@ module.exports = {
   updatePrograms,
   createProgram,
   deleteProgram,
+  getProgram,
 };


### PR DESCRIPTION
This PR adds the `/getProgram/:docID` endpoint, which is needed to implement view-only code views. 

The API is pretty simple: it's a GET endpoint with `docID` that corresponds to the hash of a program in our database's top-level programs object. Then, it either returns the program in the `sketch` key of its return object, or errors with a non-ok response.